### PR TITLE
Compute median and IQR with CSV-to-table script

### DIFF
--- a/wandb_csv_to_table.py
+++ b/wandb_csv_to_table.py
@@ -115,10 +115,10 @@ def main(
     print("Settings:")
     print(f"    aggregation (-a):  {aggregation.value}")
     print(f"    classifiers (-c):  {list(classifiers)}")
-    print(f"    groupby (-g)    :  \"{groupby}\"")
+    print(f'    groupby (-g)    :  "{groupby}"')
     print(f"    metrics (-m)    :  [{', '.join(metric.value for metric in metrics)}]")
     print(f"    round_to (-r)   :  {round_to}")
-    print(f"    sens_attr (-s)  :  \"{sens_attr}\"")
+    print(f'    sens_attr (-s)  :  "{sens_attr}"')
     print("---------------------------------------\n")
     df = pd.read_csv(csv_file)
     rows = []


### PR DESCRIPTION
Sample output:

```
$ python wandb_csv_to_table.py ~/Downloads/perfect-cluster.tue-sweep.longer.mildly_subs_miss_s.csv -a median -r 3
---------------------------------------
Settings:
    aggregation (-a):  median
    classifiers (-c):  ['pytorch_classifier']
    groupby (-g)    :  "misc.log_method"
    metrics (-m)    :  [acc, ar, tpr, tnr]
    round_to (-r)   :  3
    sens_attr (-s)  :  "colour"
---------------------------------------

\begin{tabular}{lllll}
\toprule
 misc.log_method &    Acc. $\uparrow$ & AR ratio $\rightarrow 1.0 \leftarrow$ & TPR ratio $\rightarrow 1.0 \leftarrow$ & TNR ratio $\rightarrow 1.0 \leftarrow$ \\
\midrule
 perfect-cluster &  0.994 $\pm$ 0.026 &                     0.954 $\pm$ 0.049 &                      0.998 $\pm$ 0.007 &                      0.993 $\pm$ 0.021 \\
\bottomrule
\end{tabular}
```